### PR TITLE
fastlane: add DE locale and improve formatting for EN full description

### DIFF
--- a/metadata/de/full_description.txt
+++ b/metadata/de/full_description.txt
@@ -1,0 +1,6 @@
+<i>Musekit</i> ist eine einfache App, die alle Tools bietet, die ein Musiker benötigt, ohne störende Werbung und ohne Daten zu sammeln.
+
+<b>Features:</b>
+
+- Notengabel
+- Metronom

--- a/metadata/de/short_description.txt
+++ b/metadata/de/short_description.txt
@@ -1,0 +1,1 @@
+Eine einfache Notengabel und Metronom. Keine Ablenkungen.

--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -1,6 +1,6 @@
-A simple app providing all the tools a musician may need, without disturbing ads and without collecting any data.
+<i>Musekit</i> is a simple app providing all the tools a musician may need, without disturbing ads and without collecting any data.
 
-Features:
+<b>Features:
+
 - Tuner (Automatic & Note fork)
 - Metronome
-


### PR DESCRIPTION
This PR slightly improves formatting of the English full description, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds the German (de) locale with short and full description.